### PR TITLE
Fix for the issue #20

### DIFF
--- a/redisco/models/attributes.py
+++ b/redisco/models/attributes.py
@@ -106,7 +106,7 @@ class Attribute(object):
     def validate_uniqueness(self, instance, val):
         encoded = self.typecast_for_storage(val)
         same = len(instance.__class__.objects.filter(**{self.name: encoded}))
-        if same > 0:
+        if same > (0 if instance.is_new() else 1):
             return (self.name, 'not unique',)
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -358,6 +358,17 @@ class ModelTestCase(RediscoTestCase):
         self.assertFalse(p.is_valid())
         self.assertTrue(('name', 'required') in p.errors)
 
+    def test_validation_of_unique_fields(self):
+        class Person(models.Model):
+            name = models.CharField(required=True, unique=True)
+
+        p = Person(name="Lincoln")
+        self.assertTrue(p.is_valid())
+        self.assert_(p.save())
+
+        p_from_db = Person.objects.get_by_id(p.id)
+        self.assertTrue(p.is_valid())
+
     def test_errors(self):
         class Person(models.Model):
             name = models.CharField(required=True, unique=True)


### PR DESCRIPTION
Before this patch, this code used to fail:

```
>>> class Person(models.Model):
...     name = models.CharField(required=True, unique=True)
>>> p = Person(name='Lincoln')
>>> p.save()
>>> assert Person.objects.get_by_id(p.id).is_valid()
```
